### PR TITLE
Added Cate to IDE

### DIFF
--- a/core/data/dynamic/applications.json
+++ b/core/data/dynamic/applications.json
@@ -13508,6 +13508,22 @@
             "language": "Objective-C",
             "license": "BSD-3-Clause",
             "homepage_url": ""
+        },
+        {
+            "name": "Cate",
+            "description": "",
+            "repo_url": "https://github.com/0-AI-UG/cate",
+            "tags": [],
+            "platforms": [
+                "cross"
+            ],
+            "category": "ide",
+            "stars": 0,
+            "flags": [],
+            "last_commit": "",
+            "language": "",
+            "license": "",
+            "homepage_url": "https://cate.cero-ai.com"
         }
     ]
 }


### PR DESCRIPTION
Added Cate to ide. Cate is an open source IDE built on an infinite zoomable canvas. You arrange editors, terminals, browsers, and AI agent panels in spatial workspace instead of tabs. Electron + React + TypeScript, MIT licensed, cross-platform (macOS, Windows, Linux), 1.2k stars and in active development. Checked the archive, backlog, and existing entries for duplicates, found none.
