### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This list aims to serve as a single centralized location for the best of open so
 <details>
   <summary><b>How The List Works</b></summary><br />
 
-  Definitive-opensource was initially a single markdown file that was edited directly. However, as the list scaled, this manual approach proved cumbersome and limited. Additionally, as popularity increased, we recieved many requests for README's of individual platforms - something that would be not be realistic to do manually.
+  Definitive-opensource was initially a single markdown file that was edited directly. However, as the list scaled, this manual approach proved cumbersome and limited. Additionally, as popularity increased, we received many requests for README's of individual platforms - something that would be not be realistic to do manually.
   <p>&nbsp;</p>
   As of v0.6.2-beta, the project was fundamentally re-made. Categories and applications were put in categories.json and applications.json, respectively. Python scripts were made to generate one main list and more platform-specific lists. This was paired with GitHub actions to run the scripts when any changes were made. This opened up a world of possibilies, making refactoring the list format far easier whilst eliminating typos. 
   <p>&nbsp;</p>


### PR DESCRIPTION
Fixes a small typo in the README: `recieved` → `received`.

This is a documentation-only change.